### PR TITLE
feat: optionally support concurrent operations

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,10 +9,10 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:prettier/recommended'
   ],
   rules: {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "@typescript-eslint/ban-ts-comment": "Off"
   }
 };

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Keep in mind, that this is an investigative tool that can have a heavy impact on
 for explicit data collection activities.
 
 ### Concurrency Caveat
-This plugin currently does not support concurrent operations. That is, it only works in a lambda like environment where the node
-process will only be handling one request at a time. A feature for concurrent operation support is planned.
+Supporting concurrent requests relies on using Continuation-local storage, which has a performance cost, and so it isn't enabled by default.
+If your use case is not lambda like (node process serves one request at a time), then you will need to enable concurrency support for the plugin.
+
+Use the `enableConcurrencySupport` configuration option to enable concurrency support. 
 
 ## Usage
 Add the useNetworkViewer plugin to your envelop configuration. Note the constructor takes two parameters:
@@ -89,6 +91,7 @@ Below is a list of configuration properties and what they do
 | additionalObservers | empty array | Only the http/https observer is included by default. You must specify other observers that are use case specific (knex, redis, mysql, etc) |
 | logFunction | console.log | Specify what function is used to log network viewer info. You can specify your own logger (myLogger.debug for instance) |
 | logGraphQlDocument | false | Set to true to include the graphql operation in the log message |
+| enableConcurrencySupport | false | Support concurrent requests |
 
 
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   collectCoverage: true,
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
+  testPathIgnorePatterns: ['.d.ts', '.js'],
 };

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "@semantic-release/npm": "^9.0.1",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "@tsconfig/node12": "^1.0.11",
+    "@types/cls-hooked": "^4.3.3",
     "@types/jest": "^28.1.6",
     "@types/stubby": "^4.1.1",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
     "eslint": "^8.21.0",
@@ -82,5 +84,10 @@
         }
       ]
     ]
+  },
+  "dependencies": {
+    "@types/nanoid": "^3.0.0",
+    "cls-hooked": "^4.2.2",
+    "uuid": "^8.3.2"
   }
 }

--- a/src/NetworkObserver.ts
+++ b/src/NetworkObserver.ts
@@ -2,7 +2,7 @@ import { ContextTest } from './fauxClsHooked';
 
 export type ExecuteDoneReport = {
   label: string;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
 };
 export type OnExecuteDoneCallback = () => ExecuteDoneReport;
 

--- a/src/NetworkObserver.ts
+++ b/src/NetworkObserver.ts
@@ -1,10 +1,16 @@
+import { ContextTest } from './fauxClsHooked';
+
 export type ExecuteDoneReport = {
   label: string;
   data: Record<string, any>;
 };
 export type OnExecuteDoneCallback = () => ExecuteDoneReport;
 
+export type ExecuteArgs = {
+  contextTest: ContextTest;
+};
+
 export interface NetworkObserver {
   initialize: () => void;
-  onExecute: () => OnExecuteDoneCallback;
+  onExecute: (args: ExecuteArgs) => OnExecuteDoneCallback;
 }

--- a/src/fauxClsHooked.ts
+++ b/src/fauxClsHooked.ts
@@ -7,7 +7,7 @@ export type Namespaceish = Pick<Namespace, 'run' | 'get' | 'set' | 'bind'>;
  * It allows the plugin implementation to have the same interface when supporting concurrency or not
  */
 class FauxNamespace implements Namespaceish {
-  constructor(private name: string, private data: Record<string, any> = {}) {}
+  constructor(private name: string, private data: Record<string, unknown> = {}) {}
   get(key: string): unknown {
     return this.data[key];
   }
@@ -21,7 +21,7 @@ class FauxNamespace implements Namespaceish {
     return this.data[key] as T;
   }
 
-  bind<F>(fn: F, context: any): F {
+  bind<F>(fn: F, _context: unknown): F {
     return fn;
   }
 }

--- a/src/fauxClsHooked.ts
+++ b/src/fauxClsHooked.ts
@@ -1,0 +1,38 @@
+import { Namespace } from 'cls-hooked';
+
+export type Namespaceish = Pick<Namespace, 'run' | 'get' | 'set' | 'bind'>;
+
+/**
+ * We use faux Cls hooks when we do not need to support concurrency.
+ * It allows the plugin implementation to have the same interface when supporting concurrency or not
+ */
+class FauxNamespace implements Namespaceish {
+  constructor(private name: string, private data: Record<string, any> = {}) {}
+  get(key: string): unknown {
+    return this.data[key];
+  }
+
+  run(func: () => void): void {
+    func();
+  }
+
+  set<T>(key: string, value: T): T {
+    this.data[key] = value;
+    return this.data[key] as T;
+  }
+
+  bind<F>(fn: F, context: any): F {
+    return fn;
+  }
+}
+
+export const createNamespace = (name: string): Namespaceish => {
+  return new FauxNamespace(name);
+};
+
+export class ContextTest {
+  constructor(private readonly targetId: string, private namespace: Namespaceish) {}
+  isTargetContext() {
+    return this.targetId === this.namespace.get('id');
+  }
+}

--- a/src/getFromAST.ts
+++ b/src/getFromAST.ts
@@ -6,6 +6,6 @@ export function getOperationName(doc: DocumentNode): string | null {
     doc.definitions
       .filter((definition) => definition.kind === 'OperationDefinition' && definition.name)
       // @ts-ignore
-      .map((x: OperationDefinitionNode) => x.name!.value)[0] || null
+      .map((x: OperationDefinitionNode) => x.name?.value)[0] || null
   );
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -43,7 +43,7 @@ describe('useNetworkViewer', () => {
     it('logGraphQlDocument:true - logs document after operation execution', async () => {
       const config: UseNetworkViewerOpts = { logFunction: jest.fn(), logGraphQlDocument: true };
       const testInstance = createTestkit([useNetworkViewer(true, config)], schema);
-      const result = await testInstance.execute(`query test { test }`);
+      await testInstance.execute(`query test { test }`);
       expect(config.logFunction).toBeCalledWith(
         'useNetworkViewer',
         expect.jsonContaining({

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ export const useNetworkViewer = (enabled = false, opts?: UseNetworkViewerOpts): 
     ...(opts?.additionalObservers || []),
   ];
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const namespace: Namespaceish = opts?.enableConcurrencySupport
     ? createNamespace('envelop-network-viewer')
     : fauxCreateNamespace('envelop-network-viewer');
@@ -37,7 +36,7 @@ export const useNetworkViewer = (enabled = false, opts?: UseNetworkViewerOpts): 
     },
     onExecute({ executeFn, setExecuteFn, args }) {
       let callbacks: Array<OnExecuteDoneCallback> = [];
-      const id = v4() as string;
+      const id = v4();
       function clsExecuteFn(args: ExecutionArgs) {
         namespace.set('id', id);
         const contextTest = new ContextTest(id, namespace);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { v4 } from 'uuid';
 import { ExecutionArgs } from 'graphql';
 
 export type UseNetworkViewerOpts = {
-  logFunction?: (message?: any, ...optionalParams: any[]) => void;
+  logFunction?: (message?: unknown, ...optionalParams: unknown[]) => void;
   logGraphQlDocument?: boolean;
   additionalObservers?: Array<NetworkObserver>;
   enableConcurrencySupport?: boolean;
@@ -46,9 +46,8 @@ export const useNetworkViewer = (enabled = false, opts?: UseNetworkViewerOpts): 
       setExecuteFn(namespace.bind(clsExecuteFn));
       return {
         onExecuteDone: (payload) => {
-          return handleStreamOrSingleExecutionResult(payload, ({ result, setResult }) => {
+          return handleStreamOrSingleExecutionResult(payload, () => {
             const observations = callbacks.map((callback) => callback());
-            // Here you can access result, and modify it with setResult if needed
             logFunction(
               'useNetworkViewer',
               JSON.stringify(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,18 @@
 import { Plugin, handleStreamOrSingleExecutionResult } from '@envelop/core';
 import { getOperationName } from './getFromAST';
 import { print } from 'graphql/language/printer';
-import { NetworkObserver } from './NetworkObserver';
+import { NetworkObserver, OnExecuteDoneCallback } from './NetworkObserver';
 import { HttpObserver } from './observers/httpObserver';
+import { ContextTest, createNamespace as fauxCreateNamespace, Namespaceish } from './fauxClsHooked';
+import { createNamespace } from 'cls-hooked';
+import { v4 } from 'uuid';
+import { ExecutionArgs } from 'graphql';
 
 export type UseNetworkViewerOpts = {
   logFunction?: (message?: any, ...optionalParams: any[]) => void;
   logGraphQlDocument?: boolean;
   additionalObservers?: Array<NetworkObserver>;
+  enableConcurrencySupport?: boolean;
 };
 
 export const useNetworkViewer = (enabled = false, opts?: UseNetworkViewerOpts): Plugin => {
@@ -21,12 +26,25 @@ export const useNetworkViewer = (enabled = false, opts?: UseNetworkViewerOpts): 
     ...(opts?.additionalObservers || []),
   ];
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const namespace: Namespaceish = opts?.enableConcurrencySupport
+    ? createNamespace('envelop-network-viewer')
+    : fauxCreateNamespace('envelop-network-viewer');
+
   return {
     onPluginInit() {
       observers.forEach((observer) => observer.initialize());
     },
-    onExecute({ args }) {
-      const callbacks = observers.map((observer) => observer.onExecute());
+    onExecute({ executeFn, setExecuteFn, args }) {
+      let callbacks: Array<OnExecuteDoneCallback> = [];
+      const id = v4() as string;
+      function clsExecuteFn(args: ExecutionArgs) {
+        namespace.set('id', id);
+        const contextTest = new ContextTest(id, namespace);
+        callbacks = observers.map((observer) => observer.onExecute({ contextTest }));
+        return executeFn(args);
+      }
+      setExecuteFn(namespace.bind(clsExecuteFn));
       return {
         onExecuteDone: (payload) => {
           return handleStreamOrSingleExecutionResult(payload, ({ result, setResult }) => {
@@ -37,6 +55,7 @@ export const useNetworkViewer = (enabled = false, opts?: UseNetworkViewerOpts): 
               JSON.stringify(
                 {
                   operationName: getOperationName(args.document),
+                  operationId: id,
                   document: opts?.logGraphQlDocument ? print(args.document) : undefined,
                   observations,
                 },

--- a/src/observers/httpObserver/index.test.ts
+++ b/src/observers/httpObserver/index.test.ts
@@ -1,0 +1,102 @@
+import { v4 } from 'uuid';
+import { ContextTest, createNamespace } from '../../fauxClsHooked';
+import { ExecutionListener } from './index';
+import EventEmitter from 'events';
+import { EVENT_REQUEST, EVENT_RESPONSE, RequestEventArgs, ResponseEventArgs } from './override';
+
+function stubRequestEventArgs(): RequestEventArgs {
+  return {
+    connectionID: v4(),
+    headers: {},
+    host: 'localhost',
+    method: 'GET',
+    port: '80',
+    time: Date.now(),
+  };
+}
+function stubResponseEventArgs(connectionID: string): ResponseEventArgs {
+  return {
+    connectionID,
+    headers: {},
+    httpVersion: '1.1',
+    statusCode: 200,
+    statusMessage: 'Successful',
+    time: Date.now(),
+  };
+}
+
+describe('httpObserver/index', () => {
+  describe('ExecutionListener', () => {
+    it('only collects events if event originated from target context', () => {
+      const targetId = v4();
+      const otherId = v4();
+      const namespace = createNamespace('faux');
+      const contextTest = new ContextTest(targetId, namespace);
+      const emitter = new EventEmitter();
+      const listener = new ExecutionListener(contextTest);
+      listener.bind(emitter);
+
+      const requestA = stubRequestEventArgs();
+      const responseA = stubResponseEventArgs(requestA.connectionID);
+      const requestB = stubRequestEventArgs();
+      const responseB = stubResponseEventArgs(requestB.connectionID);
+
+      namespace.set('id', otherId);
+      emitter.emit(EVENT_REQUEST, requestA);
+      namespace.set('id', targetId);
+      emitter.emit(EVENT_REQUEST, requestB);
+      emitter.emit(EVENT_RESPONSE, responseB);
+      namespace.set('id', otherId);
+      emitter.emit(EVENT_RESPONSE, responseA);
+
+      const collectedData = listener._getData();
+      expect(Object.keys(collectedData).length).toBe(1);
+      expect(collectedData).toHaveProperty(requestB.connectionID);
+      expect(collectedData[requestB.connectionID]).toEqual(requestB);
+      expect(collectedData[requestB.connectionID]).toHaveProperty('response');
+      expect(collectedData[requestB.connectionID].response).toEqual(responseB);
+    });
+    it('reports collected events', () => {
+      const targetId = v4();
+      const namespace = createNamespace('faux');
+      const contextTest = new ContextTest(targetId, namespace);
+      const emitter = new EventEmitter();
+      const listener = new ExecutionListener(contextTest);
+      listener.bind(emitter);
+
+      const requestA = stubRequestEventArgs();
+      const responseA = stubResponseEventArgs(requestA.connectionID);
+      const requestB = stubRequestEventArgs();
+      const responseB = stubResponseEventArgs(requestB.connectionID);
+
+      namespace.set('id', targetId);
+      emitter.emit(EVENT_REQUEST, requestA);
+      emitter.emit(EVENT_RESPONSE, responseA);
+      emitter.emit(EVENT_REQUEST, requestB);
+      emitter.emit(EVENT_RESPONSE, responseB);
+
+      const report = listener.report();
+      expect(report).toEqual(
+        expect.objectContaining({
+          label: 'HTTP/HTTPS',
+          data: {
+            calls: 2,
+            hosts: ['localhost'],
+            requests: expect.arrayContaining([
+              {
+                ...requestA,
+                response: responseA,
+                duration_ms: 0,
+              },
+              {
+                ...requestB,
+                response: responseB,
+                duration_ms: 0,
+              },
+            ]),
+          },
+        }),
+      );
+    });
+  });
+});

--- a/src/observers/httpObserver/index.ts
+++ b/src/observers/httpObserver/index.ts
@@ -77,8 +77,8 @@ export class ExecutionListener {
 
   report(): ExecuteDoneReport {
     const calls = Object.keys(this.data).length;
-    const hosts = Array.from(new Set(Object.entries(this.data).map(([key, value]) => value.host)));
-    const requests = Object.entries(this.data).map(([key, value]) => {
+    const hosts = Array.from(new Set(Object.entries(this.data).map(([_key, value]) => value.host)));
+    const requests = Object.entries(this.data).map(([_key, value]) => {
       const request: DeepPartial<RequestDetails> & { duration_ms?: number } = value;
       delete request.connectionID;
       delete request.response?.connectionID;

--- a/src/observers/httpObserver/index.ts
+++ b/src/observers/httpObserver/index.ts
@@ -12,8 +12,6 @@ import {
 import { DeepPartial } from '../../deepPartial';
 import { ContextTest } from '../../fauxClsHooked';
 
-export type HttpObserverConfig = {};
-
 export class HttpObserver implements NetworkObserver {
   constructor(private emitter: EventEmitter = new EventEmitter()) {}
   initialize() {
@@ -40,7 +38,7 @@ type RequestDetails = RequestEventArgs & {
   response?: ResponseEventArgs;
 };
 
-class ExecutionListener {
+export class ExecutionListener {
   constructor(
     private contextTest: ContextTest,
     private data: Record<string, RequestDetails> = {},
@@ -54,6 +52,11 @@ class ExecutionListener {
   unbind(emitter: EventEmitter) {
     emitter.removeListener(EVENT_REQUEST, this.handleRequestEvent.bind(this));
     emitter.removeListener(EVENT_RESPONSE, this.handleResponseEvent.bind(this));
+  }
+
+  /** used only for testing **/
+  _getData() {
+    return this.data;
   }
 
   handleRequestEvent(event: RequestEventArgs) {
@@ -74,7 +77,7 @@ class ExecutionListener {
 
   report(): ExecuteDoneReport {
     const calls = Object.keys(this.data).length;
-    const hosts = Object.entries(this.data).map(([key, value]) => value.host);
+    const hosts = Array.from(new Set(Object.entries(this.data).map(([key, value]) => value.host)));
     const requests = Object.entries(this.data).map(([key, value]) => {
       const request: DeepPartial<RequestDetails> & { duration_ms?: number } = value;
       delete request.connectionID;

--- a/src/observers/httpObserver/integration.test.ts
+++ b/src/observers/httpObserver/integration.test.ts
@@ -5,25 +5,43 @@ import { useNetworkViewer, UseNetworkViewerOpts } from '../../index';
 import http from 'http';
 import 'jest-expect-json';
 
+const request = (url: string) => {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, (res) => {
+      let body = '';
+      res.on('data', (chunk: Buffer) => {
+        body += chunk.toString('utf-8');
+      });
+      res.on('end', () => resolve(body));
+    });
+    req.on('error', (e) => reject(e));
+    req.end();
+  });
+};
+
 describe('httpObserver', () => {
   const stubby = new Stubby();
 
   const schema = makeExecutableSchema({
-    typeDefs: `type Query { test: String }`,
+    typeDefs: [
+      `type Query { test: String }`,
+      `type Query { test2: [String] }`,
+      `type Query { test3: [String] }`,
+    ],
     resolvers: {
       Query: {
-        test: async () => {
-          return new Promise((resolve, reject) => {
-            const req = http.request('http://localhost:8883/', (res) => {
-              let body = '';
-              res.on('data', (chunk: Buffer) => {
-                body += chunk.toString('utf-8');
-              });
-              res.on('end', () => resolve(body));
-            });
-            req.on('error', (e) => reject(e));
-            req.end();
-          });
+        test: async () => request('http://localhost:8883/'),
+        test2: async () => {
+          return [
+            await request('http://localhost:8883/foo'),
+            await request('http://localhost:8883/bar'),
+          ];
+        },
+        test3: async () => {
+          return [
+            await request('http://localhost:8883/fiz'),
+            await request('http://localhost:8883/buz'),
+          ];
         },
       },
     },
@@ -38,6 +56,10 @@ describe('httpObserver', () => {
           {
             request: { url: '/$', method: 'GET' },
             response: { body: 'hello world' },
+          },
+          {
+            request: { url: '/([a-zA-Z]+)$', method: 'GET' },
+            response: { body: '<% url[0] %>', latency: 10 },
           },
         ],
       },
@@ -56,7 +78,7 @@ describe('httpObserver', () => {
   describe('integration', () => {
     it('includes http/https observations in log message', async () => {
       const config: UseNetworkViewerOpts = {
-        logFunction: jest.fn((...args) => console.log(...args)),
+        logFunction: jest.fn(),
         logGraphQlDocument: true,
       };
       const testInstance = createTestkit([useNetworkViewer(true, config)], schema);
@@ -67,8 +89,55 @@ describe('httpObserver', () => {
           operationName: 'test',
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           document: expect.stringMatching('query\\s+test\\s+{\\s+test\\s+}'),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           observations: expect.arrayContaining([expect.objectContaining({ label: 'HTTP/HTTPS' })]),
         }),
+      );
+    });
+    it('supports concurrent requests', async () => {
+      const config: UseNetworkViewerOpts = {
+        logFunction: jest.fn(),
+        logGraphQlDocument: true,
+        enableConcurrencySupport: true,
+      };
+      const testInstance = createTestkit([useNetworkViewer(true, config)], schema);
+      const results = await Promise.all([
+        testInstance.execute(`query test { test2 }`),
+        testInstance.execute(`query test2 { test3 }`),
+      ]);
+      // verify requests for paths foo and bar, and biz and buz are grouped together
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.stringMatching('/foo.+/bar'),
+      );
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.stringMatching('/fiz.+/buz'),
+      );
+      // make sure we don't see unexpected paths grouped together
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.not.stringMatching('/fiz.+/bar'),
+      );
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.not.stringMatching('/bar.+/fiz'),
+      );
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.not.stringMatching('/fiz.+/foo'),
+      );
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.not.stringMatching('/foo.+/fiz'),
+      );
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.not.stringMatching('/buz.+/foo'),
+      );
+      expect(config.logFunction).toBeCalledWith(
+        'useNetworkViewer',
+        expect.not.stringMatching('/foo.+/buz'),
       );
     });
   });

--- a/src/observers/httpObserver/integration.test.ts
+++ b/src/observers/httpObserver/integration.test.ts
@@ -64,7 +64,7 @@ describe('httpObserver', () => {
         ],
       },
       (err) => {
-        done();
+        done(err);
       },
     );
   }, 100);
@@ -82,7 +82,7 @@ describe('httpObserver', () => {
         logGraphQlDocument: true,
       };
       const testInstance = createTestkit([useNetworkViewer(true, config)], schema);
-      const result = await testInstance.execute(`query test { test }`);
+      await testInstance.execute(`query test { test }`);
       expect(config.logFunction).toBeCalledWith(
         'useNetworkViewer',
         expect.jsonContaining({
@@ -101,7 +101,7 @@ describe('httpObserver', () => {
         enableConcurrencySupport: true,
       };
       const testInstance = createTestkit([useNetworkViewer(true, config)], schema);
-      const results = await Promise.all([
+      await Promise.all([
         testInstance.execute(`query test { test2 }`),
         testInstance.execute(`query test2 { test3 }`),
       ]);

--- a/src/observers/httpObserver/override.test.ts
+++ b/src/observers/httpObserver/override.test.ts
@@ -124,7 +124,7 @@ describe('httpObserver/override', () => {
         ],
       },
       (err) => {
-        done();
+        done(err);
       },
     );
   }, 100);
@@ -171,8 +171,9 @@ describe('httpObserver/override', () => {
 
         req.on('response', (response) => {
           // data must be consumed for end event to fire
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          response.on('data', (_chunk) => {});
+          response.on('data', (_chunk) => {
+            return _chunk;
+          });
         });
         req.end();
       }, 1000);

--- a/src/observers/httpObserver/override.test.ts
+++ b/src/observers/httpObserver/override.test.ts
@@ -171,6 +171,7 @@ describe('httpObserver/override', () => {
 
         req.on('response', (response) => {
           // data must be consumed for end event to fire
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
           response.on('data', (_chunk) => {});
         });
         req.end();

--- a/src/observers/httpObserver/override.ts
+++ b/src/observers/httpObserver/override.ts
@@ -13,7 +13,7 @@ export type RequestEventArgs = {
   host: string;
   port: string;
   path?: string;
-  headers: Record<string, any>;
+  headers: Record<string, unknown>;
 };
 
 export type ResponseEventArgs = {

--- a/src/observers/httpObserver/override.ts
+++ b/src/observers/httpObserver/override.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import https, { RequestOptions } from 'https';
 import EventEmitter from 'events';
 import { URL } from 'node:url';
+import { requestOptions } from './requestOptions';
 
 export const EVENT_REQUEST = 'request';
 export const EVENT_RESPONSE = 'response';
@@ -26,55 +27,6 @@ export type ResponseEventArgs = {
 };
 
 let uniqID = 0;
-
-/**
- * url can be a string or a URL object. If url is a string, it is automatically parsed with new URL(). If it is a URL object, it will be automatically converted to an ordinary options object.
- *
- * If both url and options are specified, the objects are merged, with the options properties taking precedence.
- */
-export function requestOptions(
-  urlOrOpts: string | URL | RequestOptions,
-  optionsOrCallback: RequestOptions | ((res: http.IncomingMessage) => void),
-  callback?: (res: http.IncomingMessage) => void,
-) {
-  let url: Partial<URL> = {};
-  if (typeof urlOrOpts === 'string') {
-    url = new URL(urlOrOpts);
-  } else if (urlOrOpts instanceof URL) {
-    url = urlOrOpts;
-  } else if (typeof urlOrOpts === 'object') {
-    // handled later
-  } else if (typeof optionsOrCallback !== 'object') {
-    // TODO maybe return {} instead
-    // @ts-ignore
-    // eslint-disable-next-line prefer-rest-params
-    throw new Error(
-      'invalid request options' + JSON.stringify({ urlOrOpts, optionsOrCallback, callback }),
-    );
-  }
-
-  const urlOpts = {
-    href: url.href,
-    origin: url.origin,
-    protocol: url.protocol,
-    username: url.username,
-    password: url.password,
-    host: url.host,
-    hostname: url.hostname,
-    port: url.port,
-    pathname: url.pathname,
-    search: url.search,
-    searchParams: url.searchParams,
-    hash: url.hash,
-  };
-
-  return Object.assign(
-    {},
-    urlOpts,
-    typeof urlOrOpts === 'object' ? urlOrOpts : {},
-    typeof optionsOrCallback === 'object' ? optionsOrCallback : {},
-  );
-}
 
 export type RequestArgs = [
   urlOrOpts: string | URL | RequestOptions,
@@ -110,9 +62,9 @@ export function override(module: typeof http | typeof https, emitter: EventEmitt
         connectionID,
         time: Date.now(),
         method: options.method || 'GET',
-        host: options.hostname || options.host,
+        host: options.host,
         port: options.port,
-        path: options.path || options.pathname,
+        path: options.path,
         headers: options.headers || {},
       };
       emitter.emit(EVENT_REQUEST, log);

--- a/src/observers/httpObserver/override.ts
+++ b/src/observers/httpObserver/override.ts
@@ -112,7 +112,7 @@ export function override(module: typeof http | typeof https, emitter: EventEmitt
         method: options.method || 'GET',
         host: options.hostname || options.host,
         port: options.port,
-        path: options.path,
+        path: options.path || options.pathname,
         headers: options.headers || {},
       };
       emitter.emit(EVENT_REQUEST, log);

--- a/src/observers/httpObserver/requestOptions.test.ts
+++ b/src/observers/httpObserver/requestOptions.test.ts
@@ -1,0 +1,90 @@
+import { requestOptions } from './requestOptions';
+
+describe('httpObserver/requestOptions', () => {
+  type TestCase = [
+    label: string,
+    args: [url: string | URL | Record<string, unknown>, opts: Record<string, unknown> | undefined],
+    expected: Record<string, unknown>,
+  ];
+  const testCases: Array<TestCase> = [
+    [
+      'url parameter can be a string',
+      ['http://foo.com:7373/asdf?q=red', undefined],
+      expect.objectContaining({
+        host: 'foo.com',
+        path: '/asdf?q=red',
+        port: '7373',
+        protocol: 'http:',
+      }),
+    ],
+    [
+      'url parameter can be a URL',
+      [new URL('https://bar.com/fdsa?q=blue&sort=asc'), undefined],
+      expect.objectContaining({
+        host: 'bar.com',
+        path: '/fdsa?q=blue&sort=asc',
+        port: '',
+        protocol: 'https:',
+      }),
+    ],
+    [
+      'url parameter can be a URL object',
+      [{ host: 'bar.com', path: '/fdsa?q=blue&sort=asc', port: '', protocol: 'https:' }, undefined],
+      { host: 'bar.com', path: '/fdsa?q=blue&sort=asc', port: '', protocol: 'https:' },
+    ],
+    [
+      'if url and options are specified, they are merged, options properties taking precedence',
+      [
+        'https://foobar.com/asdffdsa',
+        {
+          host: 'fizbuz.com',
+          path: '/foo/bar?category=shoes',
+          port: 8080,
+          protocol: 'http:',
+        },
+      ],
+      expect.objectContaining({
+        host: 'fizbuz.com',
+        path: '/foo/bar?category=shoes',
+        port: 8080,
+        protocol: 'http:',
+      }),
+    ],
+  ];
+  testCases.forEach((test) => {
+    const [scenario, args, expected] = test;
+    it(`${scenario}`, () => {
+      // @ts-ignore
+      const options = requestOptions(...args);
+      expect(options).toEqual(expected);
+    });
+  });
+
+  describe('unexpected parameters provided', () => {
+    type FailureCase = [label: string, args: Array<unknown>, expected: string];
+    const failureCases: Array<FailureCase> = [
+      [
+        'should throw if first parameter is not a url or options',
+        [() => {}],
+        'First parameter should be the url, or options object.',
+      ],
+      [
+        'should throw if second parameter is not an options or callback or undefined',
+        ['http://foo.com', 'http://bar.com'],
+        'Second parameter should be an options object or callback or undefined.',
+      ],
+      [
+        'should throw if third parameter is not a callback or undefined',
+        ['http://foo.com', { port: 8083 }, { contentType: 'text/json' }],
+        'Third parameter should be a callback or undefined.',
+      ],
+    ];
+    failureCases.forEach((failure) => {
+      const [scenario, args, expected] = failure;
+      it(`${scenario}`, () => {
+        // @ts-ignore
+        expect(() => requestOptions(...args)).toThrowError(expected);
+      });
+    });
+  });
+});

--- a/src/observers/httpObserver/requestOptions.test.ts
+++ b/src/observers/httpObserver/requestOptions.test.ts
@@ -65,7 +65,7 @@ describe('httpObserver/requestOptions', () => {
     const failureCases: Array<FailureCase> = [
       [
         'should throw if first parameter is not a url or options',
-        [() => {}],
+        [() => 'no-op'],
         'First parameter should be the url, or options object.',
       ],
       [

--- a/src/observers/httpObserver/requestOptions.ts
+++ b/src/observers/httpObserver/requestOptions.ts
@@ -1,0 +1,59 @@
+import { URL } from 'node:url';
+import { RequestOptions } from 'https';
+import http from 'http';
+
+/**
+ * url can be a string or a URL object. If url is a string, it is automatically parsed with new URL(). If it is a URL object, it will be automatically converted to an ordinary options object.
+ *
+ * If both url and options are specified, the objects are merged, with the options properties taking precedence.
+ */
+export function requestOptions(
+  urlOrOpts: string | URL | RequestOptions,
+  optionsOrCallback: RequestOptions | ((res: http.IncomingMessage) => void),
+  callback?: (res: http.IncomingMessage) => void,
+) {
+  let url: Partial<URL> = {};
+  if (typeof urlOrOpts === 'string') {
+    url = new URL(urlOrOpts);
+  } else if (urlOrOpts instanceof URL) {
+    url = urlOrOpts;
+  } else if (typeof urlOrOpts === 'object') {
+    // handled later
+  } else {
+    throw new Error(
+      'First parameter should be the url, or options object. Got ' + typeof urlOrOpts,
+    );
+  }
+
+  if (
+    typeof optionsOrCallback !== 'undefined' &&
+    typeof optionsOrCallback !== 'object' &&
+    typeof optionsOrCallback !== 'function'
+  ) {
+    throw new Error(
+      'Second parameter should be an options object or callback or undefined. Got ' +
+        typeof optionsOrCallback,
+    );
+  }
+
+  if (typeof callback !== 'function' && typeof callback !== 'undefined') {
+    throw new Error('Third parameter should be a callback or undefined. Got ' + typeof callback);
+  }
+
+  const urlOpts = {
+    protocol: url.protocol,
+    host: url.hostname,
+    port: url.port,
+    path: url.pathname
+      ? url.pathname +
+        (url.searchParams?.toString() === '' ? '' : `?${url.searchParams?.toString()}`)
+      : undefined,
+  };
+
+  return Object.assign(
+    {},
+    urlOpts,
+    typeof urlOrOpts === 'object' ? urlOrOpts : {},
+    typeof optionsOrCallback === 'object' ? optionsOrCallback : {},
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*.ts", "jest.config.js"],
   "exclude": ["node_modules", "dist", "src/**/*.spec.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,6 +1252,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cls-hooked@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cls-hooked/-/cls-hooked-4.3.3.tgz#c09e2f8dc62198522eaa18a5b6b873053154bd00"
+  integrity sha512-gNstDTb/ty5h6gJd6YpSPgsLX9LmRpaKJqGFp7MRlYxhwp4vXXKlJ9+bt1TZ9KbVNXE+Mbxy2AYXcpY21DDtJw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1296,6 +1303,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/nanoid@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/nanoid/-/nanoid-3.0.0.tgz#c757b20f343f3a1dd76e80a9a431b6290fc20f35"
+  integrity sha512-UXitWSmXCwhDmAKe7D3hNQtQaHeHt5L8LO1CB8GF8jlYVzOv5cBWDNqiJ+oPEWrWei3i3dkZtHY/bUtd0R/uOQ==
+  dependencies:
+    nanoid "*"
+
 "@types/node@*", "@types/node@>=12":
   version "18.6.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
@@ -1332,6 +1346,11 @@
   integrity sha512-yEQLYroFv8maE+tsoJkegbRJehOV3ljGA5lWTCfekD2XR+WjkCfEOZ7pHcXo+4fShr3pbaFAC3ejtsQ0ipJKAw==
   dependencies:
     "@types/node" "*"
+
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -1607,6 +1626,13 @@ asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
 
 async@^3.2.3:
   version "3.2.4"
@@ -1908,6 +1934,15 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
 
 cmd-shim@^5.0.0:
   version "5.0.0"
@@ -2261,6 +2296,13 @@ electron-to-chromium@^1.4.202:
   version "1.4.210"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz#12611fe874b833a3bf3671438b5893aba7858980"
   integrity sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==
+
+emitter-listener@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
+  dependencies:
+    shimmer "^1.2.0"
 
 emittery@^0.10.2:
   version "0.10.2"
@@ -4156,6 +4198,11 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+nanoid@*:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.0.tgz#6e144dee117609232c3f415c34b0e550e64999a5"
+  integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5076,7 +5123,7 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.4.tgz#13053c0d4aa11d070a2f2872b6b1e3ae1e1971b4"
   integrity sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==
 
-"semver@2 || 3 || 4 || 5":
+"semver@2 || 3 || 4 || 5", semver@^5.4.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -5109,6 +5156,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shimmer@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
@@ -5232,6 +5284,11 @@ ssri@^9.0.0, ssri@^9.0.1:
   integrity sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==
   dependencies:
     minipass "^3.1.1"
+
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==
 
 stack-utils@^2.0.3:
   version "2.0.5"
@@ -5641,6 +5698,11 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Implements https://github.com/FormidableLabs/envelop-network-viewer/issues/6 adding a configuration option that will enable concurrent execution support.


Uses cls-hooked to register a context for each request.
Introduces a "ContextTest" object that is passed to observer onExecute methods that can be used to test if the current execution belongs to the target context. 

## Todo
- [x] unit tests