### PR TITLE
feat: added typeorm observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,46 @@ const getEnveloped = envelop({
   ]
 })
 ```
+
+### TypeORM Observer
+If your application uses TypeORM, you'll want to include the `TypeORMObserver` in your configuration of the plugin. 
+The TypeORM observer provides observations for your database interactions using the TypeORM datasource.
+
+#### Usage
+You'll need to initialize the TypeORM datasource with `options.logger` set to an instance of `TypeORMObserverLogger`.
+Then pass the instance of the `TypeORMObserverLogger` when instantiating the `TypeORMObserver`. 
+Finally, pass the `TypeORMObserver` instance in the `additionalObservers` configuration.   
+
+```typescript
+const typeOrmObserverLogger = new TypeOrmObserverLogger();
+
+const datasource = new DataSource({
+  type: 'sqlite',
+  database: ':memory:',
+  logger: typeOrmObserverLogger,
+  logging: ['error'], // still respected
+});
+
+const useNetworkViewerConfig = {
+  additionalObservers: [new TypeORMObserver(typeOrmObserverLogger)]
+};
+
+const getEnveloped = envelop({
+  plugins: [
+    useNetworkViewer(true, useNetworkViewerConfig)
+  ]
+})
+```
+
+If you've already configured your datasource with `logger` and `logging` value, you can provide those to `TypeORMObserverLogger` instead. 
+The `TypeORMObserverLogger` will pass all logging to the provided logger.
+
+Example, to use one the built-in file logger to log query errors then you would use the following
+to initialize the `TypeORMObserverLogger`
+
+```typescript 
+const typeOrmObserverLogger = new TypeOrmObserverLogger(
+  "file", /* or any valid DataSourceOptions.logger value */ 
+  ['error'] /* or any valid DataSourceOptions.logging value */)
+);
+```

--- a/package.json
+++ b/package.json
@@ -45,9 +45,36 @@
     "graphql": "^16.5.0",
     "knex": "^2.2.0",
     "prisma": "^4.2.1",
+    "reflect-metadata": "^0.1.13",
     "sequelize": "^6.21.3",
     "sqlite3": "^5.0.11",
-    "yarn": "^1.22.19"
+    "typeorm": "^0.3.7"
+  },
+  "peerDependenciesMeta": {
+    "soy-milk": {
+      "optional": true
+    },
+    "@prisma/client": {
+      "optional": true
+    },
+    "knex": {
+      "optional": true
+    },
+    "prisma": {
+      "optional": true
+    },
+    "reflect-metadata": {
+      "optional": true
+    },
+    "sequelize": {
+      "optional": true
+    },
+    "sqlite3": {
+      "optional": true
+    },
+    "typeorm": {
+      "optional": true
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/src/observers/sequelizeObserver/integration.test.ts
+++ b/src/observers/sequelizeObserver/integration.test.ts
@@ -97,15 +97,15 @@ describe('sequelizeObserver/integration', () => {
       ),
     );
     // make sure these do not occur together
-    expect(config.logFunction).toBeCalledWith(
+    expect(config.logFunction).not.toBeCalledWith(
       'useNetworkViewer',
-      expect.not.stringMatching(
+      expect.stringMatching(
         `"sql":"SELECT \`id\`, \`firstName\`, \`lastName\`, \`birthday\`, \`createdAt\`, \`updatedAt\` FROM \`authors\` AS \`author\` WHERE \`author\`.\`id\` = '1';".*"sql":"SELECT \`id\`, \`firstName\`, \`lastName\`, \`birthday\`, \`createdAt\`, \`updatedAt\` FROM \`authors\` AS \`author\`;"`,
       ),
     );
-    expect(config.logFunction).toBeCalledWith(
+    expect(config.logFunction).not.toBeCalledWith(
       'useNetworkViewer',
-      expect.not.stringMatching(
+      expect.stringMatching(
         `"sql":"SELECT \`id\`, \`firstName\`, \`lastName\`, \`birthday\`, \`createdAt\`, \`updatedAt\` FROM \`authors\` AS \`author\`;".*"sql":"SELECT \`id\`, \`firstName\`, \`lastName\`, \`birthday\`, \`createdAt\`, \`updatedAt\` FROM \`authors\` AS \`author\` WHERE \`author\`.\`id\` = '1';"`,
       ),
     );

--- a/src/observers/typeormObserver/executionListener.test.ts
+++ b/src/observers/typeormObserver/executionListener.test.ts
@@ -1,0 +1,78 @@
+import { EVENT_LOG_QUERY, EventLogQueryArgs } from './logger';
+import { v4 } from 'uuid';
+import { ContextTest, createNamespace } from '../../fauxClsHooked';
+import EventEmitter from 'events';
+import { ExecutionListener } from './executionListener';
+
+function stubQueryEventArgs(sql: string): EventLogQueryArgs {
+  return {
+    query: sql,
+    parameters: [],
+  };
+}
+
+describe('typeormObserver/executionListener', () => {
+  it('only collects events if event originated from target context', () => {
+    const targetId = v4();
+    const otherId = v4();
+    const namespace = createNamespace('faux');
+    const contextTest = new ContextTest(targetId, namespace);
+    const emitter = new EventEmitter();
+    const listener = new ExecutionListener(contextTest);
+    listener.bind(emitter);
+
+    const queryA = stubQueryEventArgs("select * from authors where firstName = 'Jane'");
+    const queryB = stubQueryEventArgs("select * from authors where firstName = 'Robin'");
+    const queryC = stubQueryEventArgs("select * from authors where lastName = 'Tolkien'");
+
+    namespace.set('id', otherId);
+    emitter.emit(EVENT_LOG_QUERY, queryA);
+    namespace.set('id', targetId);
+    emitter.emit(EVENT_LOG_QUERY, queryB);
+    namespace.set('id', otherId);
+    emitter.emit(EVENT_LOG_QUERY, queryC);
+
+    const collectedData = listener._getData();
+    expect(collectedData).toHaveLength(1);
+    expect(collectedData).toEqual(expect.arrayContaining([queryB]));
+  });
+  it('reports collected events', () => {
+    const targetId = v4();
+    const namespace = createNamespace('faux');
+    const contextTest = new ContextTest(targetId, namespace);
+    const emitter = new EventEmitter();
+    const listener = new ExecutionListener(contextTest);
+    listener.bind(emitter);
+
+    const queryA = stubQueryEventArgs("select * from authors where firstName = 'Jane'");
+    const queryB = stubQueryEventArgs("select * from authors where firstName = 'Robin'");
+
+    namespace.set('id', targetId);
+    emitter.emit(EVENT_LOG_QUERY, queryA);
+    emitter.emit(EVENT_LOG_QUERY, queryB);
+
+    const report = listener.report();
+    expect(report).toEqual(
+      expect.objectContaining({
+        label: 'TYPEORM',
+        data: {
+          calls: 2,
+          queries: expect.arrayContaining([queryA, queryB]),
+        },
+      }),
+    );
+  });
+  it('does not report if events were not collected', () => {
+    const targetId = v4();
+    const namespace = createNamespace('faux');
+    const contextTest = new ContextTest(targetId, namespace);
+    const emitter = new EventEmitter();
+    const listener = new ExecutionListener(contextTest);
+    listener.bind(emitter);
+
+    namespace.set('id', targetId);
+
+    const report = listener.report();
+    expect(report).toBe(null);
+  });
+});

--- a/src/observers/typeormObserver/executionListener.ts
+++ b/src/observers/typeormObserver/executionListener.ts
@@ -1,0 +1,35 @@
+import { ContextTest } from '../../fauxClsHooked';
+import EventEmitter from 'events';
+import { EVENT_LOG_QUERY, EventLogQueryArgs } from './logger';
+import { ExecuteDoneReport } from '../../NetworkObserver';
+
+export class ExecutionListener {
+  constructor(private contextTest: ContextTest, private data: Array<EventLogQueryArgs> = []) {}
+
+  bind(emitter: EventEmitter) {
+    emitter.addListener(EVENT_LOG_QUERY, this.handleQueryEvent.bind(this));
+  }
+
+  unbind(emitter: EventEmitter) {
+    emitter.removeListener(EVENT_LOG_QUERY, this.handleQueryEvent.bind(this));
+  }
+
+  /** used only for testing **/
+  _getData() {
+    return this.data;
+  }
+
+  handleQueryEvent(args: EventLogQueryArgs) {
+    if (!this.contextTest.isTargetContext()) {
+      return;
+    }
+    this.data.push(args);
+  }
+
+  report(): ExecuteDoneReport {
+    if (this.data.length < 1) {
+      return null;
+    }
+    return { label: 'TYPEORM', data: { calls: this.data.length, queries: this.data } };
+  }
+}

--- a/src/observers/typeormObserver/index.ts
+++ b/src/observers/typeormObserver/index.ts
@@ -1,0 +1,30 @@
+import {
+  ExecuteArgs,
+  ExecuteDoneReport,
+  NetworkObserver,
+  OnExecuteDoneCallback,
+} from '../../NetworkObserver';
+import { TypeORMObserverLogger } from './logger';
+import EventEmitter from 'events';
+import { ExecutionListener } from './executionListener';
+
+export class TypeORMObserver implements NetworkObserver {
+  constructor(
+    private readonly logger: TypeORMObserverLogger,
+    private emitter: EventEmitter = new EventEmitter(),
+  ) {}
+
+  initialize(): void {
+    this.logger.initialize(this.emitter);
+  }
+
+  onExecute({ contextTest }: ExecuteArgs): OnExecuteDoneCallback {
+    const listener = new ExecutionListener(contextTest);
+    listener.bind(this.emitter);
+    return (): ExecuteDoneReport => {
+      const report = listener.report();
+      listener.unbind(this.emitter);
+      return report;
+    };
+  }
+}

--- a/src/observers/typeormObserver/integration.test.ts
+++ b/src/observers/typeormObserver/integration.test.ts
@@ -1,15 +1,24 @@
+import { makeDatasource } from '../../../typeorm';
+import { TypeORMObserverLogger } from './logger';
 import { makeExecutableSchema } from '@graphql-tools/schema';
+import { Author } from '../../../typeorm/Author';
 import { useNetworkViewer, UseNetworkViewerOpts } from '../../useNetworkViewer';
-import { PrismaObserver } from './index';
-import { PrismaClient } from '@prisma/client';
+import { TypeORMObserver } from './index';
 import { createTestkit } from '@envelop/testing';
 import 'jest-expect-json';
 
-describe('prismaObserver/integration', () => {
-  const prisma = new PrismaClient();
+function escapeRegex(string: string) {
+  return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+describe('typeormObserver/integration', () => {
+  const logger = new TypeORMObserverLogger();
+  const datasource = makeDatasource({
+    logger,
+  });
   const schema = makeExecutableSchema({
     typeDefs: [
-      `type Author { firstName: String! lastName: String! }`,
+      `type Author { firstName: String! lastName: String! birthday: String! }`,
       `type Query { authors: [Author] }`,
       `type Query { author(id: ID!): Author }`,
     ],
@@ -17,38 +26,34 @@ describe('prismaObserver/integration', () => {
       Query: {
         authors: async () => {
           return new Promise((resolve) => {
-            setTimeout(() => resolve(prisma.author.findMany()), 5);
+            setTimeout(() => resolve(datasource.manager.find(Author)), 5);
           });
         },
         author: async (_parent, args: { id: number }) => {
           return new Promise((resolve) => {
-            setTimeout(
-              () =>
-                resolve(
-                  prisma.author.findUnique({
-                    where: {
-                      id: args.id,
-                    },
-                  }),
-                ),
-              5,
-            );
+            setTimeout(() => resolve(datasource.manager.findBy(Author, { id: args.id })), 5);
           });
         },
       },
     },
   });
 
-  beforeEach(() => jest.resetModules());
-  afterEach(async () => {
-    return prisma.$disconnect();
+  beforeAll(async () => {
+    await datasource.initialize();
+    const author = new Author();
+    author.first_name = 'Terry';
+    author.last_name = 'Mancour';
+    await datasource.manager.save(author);
+  });
+  afterAll(async () => {
+    await datasource.destroy();
   });
 
-  it('includes prisma observations in log message', async () => {
+  it('includes typeorm observations in log message', async () => {
     const config: UseNetworkViewerOpts = {
       logFunction: jest.fn(),
       logGraphQlDocument: true,
-      additionalObservers: [new PrismaObserver(prisma)],
+      additionalObservers: [new TypeORMObserver(logger)],
     };
     const testInstance = createTestkit([useNetworkViewer(true, config)], schema);
     await testInstance.execute(`query authors { authors { firstName lastName } }`);
@@ -61,40 +66,39 @@ describe('prismaObserver/integration', () => {
           'query\\s+authors\\s+{\\s+authors\\s+{\\s+firstName\\s+lastName\\s+}\\s+}',
         ),
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        observations: expect.arrayContaining([expect.objectContaining({ label: 'PRISMA' })]),
+        observations: expect.arrayContaining([expect.objectContaining({ label: 'TYPEORM' })]),
       }),
     );
   });
+
   it('supports concurrent requests', async () => {
     const config: UseNetworkViewerOpts = {
       logFunction: jest.fn(),
       logGraphQlDocument: true,
-      additionalObservers: [new PrismaObserver(prisma)],
+      additionalObservers: [new TypeORMObserver(logger)],
     };
     const testInstance = createTestkit([useNetworkViewer(true, config)], schema);
     await testInstance.execute(`query author { author(id: 1) { firstName lastName } }`);
     await testInstance.execute(`query authors { authors { firstName lastName } }`);
     expect(config.logFunction).toHaveBeenCalledTimes(2);
-    expect(config.logFunction).toBeCalledWith(
-      'useNetworkViewer',
-      expect.stringMatching(`"args":{"where":{"id":"1"}}.*"action":"findUnique","model":"Author"`),
+
+    const queryA = JSON.stringify(
+      `SELECT "Author"."id" AS "Author_id", "Author"."first_name" AS "Author_first_name", "Author"."last_name" AS "Author_last_name" FROM "author" "Author"`,
     );
-    expect(config.logFunction).toBeCalledWith(
-      'useNetworkViewer',
-      expect.stringMatching(`"action":"findMany","model":"Author"`),
+    const queryB = JSON.stringify(
+      `SELECT "Author"."id" AS "Author_id", "Author"."first_name" AS "Author_first_name", "Author"."last_name" AS "Author_last_name" FROM "author" "Author" WHERE ("Author"."id" = ?)`,
     );
+
+    expect(config.logFunction).toBeCalledWith('useNetworkViewer', expect.stringContaining(queryA));
+    expect(config.logFunction).toBeCalledWith('useNetworkViewer', expect.stringContaining(queryB));
     // make sure these do not occur together
     expect(config.logFunction).not.toBeCalledWith(
       'useNetworkViewer',
-      expect.stringMatching(
-        `"action":"findUnique","model":"Author".*"action":"findMany","model":"Author"`,
-      ),
+      expect.stringMatching(`${escapeRegex(queryA)}.*${escapeRegex(queryB)}`),
     );
     expect(config.logFunction).not.toBeCalledWith(
       'useNetworkViewer',
-      expect.stringMatching(
-        `"action":"findMany","model":"Author".*"action":"findUnique","model":"Author"`,
-      ),
+      expect.stringMatching(`${escapeRegex(queryB)}.*${escapeRegex(queryA)}`),
     );
   });
 });

--- a/src/observers/typeormObserver/logger.test.ts
+++ b/src/observers/typeormObserver/logger.test.ts
@@ -1,0 +1,51 @@
+import { EVENT_LOG_QUERY, TypeORMObserverLogger } from './logger';
+import { Logger } from 'typeorm';
+import EventEmitter from 'events';
+
+describe('typeormObserver/logger', () => {
+  describe('passthru', () => {
+    type testCase = [method: keyof Logger, args: unknown[]];
+    const testCases: Array<testCase> = [
+      ['log', ['all', 'my message', undefined]],
+      ['logMigration', ['migration message', undefined]],
+      ['logQuery', ['select * from authors', [], undefined]],
+      ['logQueryError', [new Error('bad query'), 'select all from table authors', [], undefined]],
+      ['logQuerySlow', [2000, 'select * from authors', [], undefined]],
+      ['logSchemaBuild', ['built schema', undefined]],
+    ];
+    testCases.forEach((testCase) => {
+      const [method, args] = testCase;
+      it(`constructed with logger: ${method} passed thru`, () => {
+        const passThru: Logger = {
+          log: jest.fn(),
+          logMigration: jest.fn(),
+          logQuery: jest.fn(),
+          logQueryError: jest.fn(),
+          logQuerySlow: jest.fn(),
+          logSchemaBuild: jest.fn(),
+        };
+        const logger = new TypeORMObserverLogger(passThru);
+        // @ts-ignore
+        logger[method](...args);
+        expect(passThru[method]).toHaveBeenCalledWith(...args);
+      });
+      it(`constructed without logger: ${method} not passed thru`, () => {
+        const logger = new TypeORMObserverLogger();
+        // @ts-ignore
+        logger[method](...args); // if it doesn't blow up, we're good
+      });
+    });
+  });
+
+  it('logQuery emits', () => {
+    const emitter = new EventEmitter();
+    emitter.emit = jest.fn();
+    const query = 'select * from authors where id = ?';
+    const parameters = [1];
+    const logger = new TypeORMObserverLogger();
+    logger.initialize(emitter);
+    logger.logQuery(query, parameters);
+
+    expect(emitter.emit).toHaveBeenCalledWith(EVENT_LOG_QUERY, { query, parameters });
+  });
+});

--- a/src/observers/typeormObserver/logger.ts
+++ b/src/observers/typeormObserver/logger.ts
@@ -1,0 +1,59 @@
+import { Logger, QueryRunner } from 'typeorm';
+import { LoggerFactory } from 'typeorm/logger/LoggerFactory';
+import { LoggerOptions } from 'typeorm/logger/LoggerOptions';
+import EventEmitter from 'events';
+
+export const EVENT_LOG_QUERY = 'logQuery';
+export type EventLogQueryArgs = {
+  query: string;
+  parameters?: Array<unknown>;
+};
+
+export class TypeORMObserverLogger implements Logger {
+  private readonly logger?: Logger;
+  private emitter?: EventEmitter;
+  constructor(
+    logger?: 'advanced-console' | 'simple-console' | 'file' | 'debug' | Logger,
+    options?: LoggerOptions,
+  ) {
+    if (logger) {
+      this.logger = new LoggerFactory().create(logger, options);
+    }
+  }
+
+  initialize(emitter: EventEmitter) {
+    this.emitter = emitter;
+  }
+
+  log(level: 'log' | 'info' | 'warn', message: any, queryRunner?: QueryRunner): any {
+    if (this.logger) return this.logger.log(level, message, queryRunner);
+  }
+
+  logMigration(message: string, queryRunner?: QueryRunner): any {
+    if (this.logger) return this.logger.logMigration(message, queryRunner);
+  }
+
+  logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner): any {
+    if (this.emitter) {
+      this.emitter.emit(EVENT_LOG_QUERY, { query, parameters });
+    }
+    if (this.logger) return this.logger.logQuery(query, parameters, queryRunner);
+  }
+
+  logQueryError(
+    error: string | Error,
+    query: string,
+    parameters?: any[],
+    queryRunner?: QueryRunner,
+  ): any {
+    if (this.logger) return this.logger.logQueryError(error, query, parameters, queryRunner);
+  }
+
+  logQuerySlow(time: number, query: string, parameters?: any[], queryRunner?: QueryRunner): any {
+    if (this.logger) return this.logger.logQuerySlow(time, query, parameters, queryRunner);
+  }
+
+  logSchemaBuild(message: string, queryRunner?: QueryRunner): any {
+    if (this.logger) return this.logger.logSchemaBuild(message, queryRunner);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDirs": ["src", "typeorm"],
     "outDir": "dist",
     "declaration": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
   },
-  "include": ["src/**/*.ts", "jest.config.js"],
+  "include": ["src/**/*.ts", "jest.config.js", "typeorm/*.ts"],
   "exclude": ["node_modules", "dist", "src/**/*.spec.ts"]
 }

--- a/typeorm/Author.ts
+++ b/typeorm/Author.ts
@@ -1,0 +1,11 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class Author {
+  // @ts-ignore
+  @PrimaryColumn() id: number;
+  // @ts-ignore
+  @Column() first_name: string;
+  // @ts-ignore
+  @Column() last_name: string;
+}

--- a/typeorm/index.ts
+++ b/typeorm/index.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { Author } from './Author';
+import { DataSourceOptions } from 'typeorm/data-source/DataSourceOptions';
+
+export const makeDatasource = (config: Partial<DataSourceOptions>) => {
+  const defaults: DataSourceOptions = {
+    type: 'sqlite',
+    database: ':memory:',
+    dropSchema: true,
+    synchronize: true,
+    entities: [Author],
+  };
+  return new DataSource(Object.assign({}, defaults, config));
+};


### PR DESCRIPTION
Implements https://github.com/FormidableLabs/envelop-network-viewer/issues/12 adding an additional TypeORM datasource observer.

chore: use correct assertions - logger should not be called w/ matching values
chore: package.json marking peer deps as optional